### PR TITLE
[Fix]: Duplicate cmt report

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch file",
+            "name": "Launch Jira Daily Report",
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            "program": "${file}",
+            "program": "${workspaceFolder}/cmd/jira-daily-report/main.go",
             "envFile": "${workspaceFolder}/.env",
+            "cwd": "${workspaceFolder}"
         }
-
     ]
 }

--- a/internal/msteams/jira_formatter.go
+++ b/internal/msteams/jira_formatter.go
@@ -36,14 +36,15 @@ type EpicGroup struct {
 
 // IssueUpdate represents an issue with its updates
 type IssueUpdate struct {
-	Key         string
-	Summary     string
-	Status      string
-	IssueType   string
-	URL         string
-	Updates     []Update
-	LastUpdated time.Time
-	SubTasks    []IssueUpdate // Sub-tasks belonging to this issue
+	Key           string
+	Summary       string
+	Status        string
+	IssueType     string
+	URL           string
+	Updates       []Update
+	LastUpdated   time.Time
+	SubTasks      []IssueUpdate // Sub-tasks belonging to this issue
+	AddedToReport bool          // Track if this issue has been added to the final report
 }
 
 // Update represents a single update (comment or worklog)

--- a/pkg/jira-report/generator.go
+++ b/pkg/jira-report/generator.go
@@ -491,36 +491,3 @@ func convertUpdates(updates []Update) []msteams.Update {
 	}
 	return msteamsUpdates
 }
-
-// FormatAsAdaptiveCard creates an AdaptiveCard from the provided data
-// This is a public function that allows external users to create AdaptiveCards
-// without needing access to the internal msteams package
-func FormatAsAdaptiveCard(epicGroups map[string]*EpicGroup, noEpicIssues []IssueUpdate, reportDate time.Time, timezone string) msteams.AdaptiveCard {
-	// Convert public types to internal msteams types
-	msteamsEpicGroups := make(map[string]*msteams.EpicGroup)
-	for key, group := range epicGroups {
-		msteamsEpicGroups[key] = &msteams.EpicGroup{
-			EpicKey:     group.EpicKey,
-			EpicSummary: group.EpicSummary,
-			EpicStatus:  group.EpicStatus,
-			EpicURL:     group.EpicURL,
-			Issues:      convertIssueUpdates(group.Issues),
-		}
-	}
-
-	msteamsNoEpicIssues := convertIssueUpdates(noEpicIssues)
-
-	// Create a basic subtitle config for standalone usage
-	subtitleConfig := msteams.SubtitleConfig{
-		QueryType:     "manual",
-		LookbackHours: 24,
-	}
-
-	return msteams.FormatJiraReportAsAdaptiveCard(msteamsEpicGroups, msteamsNoEpicIssues, reportDate, timezone, subtitleConfig)
-}
-
-// FormatAsTeamsMessage creates a Teams message from an AdaptiveCard
-// This wraps the AdaptiveCard in the proper Teams message structure
-func FormatAsTeamsMessage(adaptiveCard msteams.AdaptiveCard) msteams.TeamsMessage {
-	return msteams.FormatTeamsMessage(adaptiveCard)
-}

--- a/pkg/jira-report/types.go
+++ b/pkg/jira-report/types.go
@@ -17,14 +17,15 @@ type EpicGroup struct {
 
 // IssueUpdate represents an issue with its updates
 type IssueUpdate struct {
-	Key         string
-	Summary     string
-	Status      string
-	IssueType   string
-	URL         string
-	Updates     []Update
-	LastUpdated time.Time
-	SubTasks    []IssueUpdate // Sub-tasks belonging to this issue
+	Key           string
+	Summary       string
+	Status        string
+	IssueType     string
+	URL           string
+	Updates       []Update
+	LastUpdated   time.Time
+	SubTasks      []IssueUpdate // Sub-tasks belonging to this issue
+	AddedToReport bool          // Track if this issue has been added to the final report
 }
 
 // Update represents a single update (comment or worklog)


### PR DESCRIPTION
Root cause:
When a sub-task is found, the code fetches its parent task and adds it to the report, but if that parent task has already been processed before, it will be added again.

Additional: add launch.js to run debug mode